### PR TITLE
update references to ec-cli repository

### DIFF
--- a/2024-SOSS-EU/run-demos.sh
+++ b/2024-SOSS-EU/run-demos.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o pipefail
 
 image=$(podman build --quiet --file <(cat <<DOCKERFILE
-FROM quay.io/enterprise-contract/ec-cli:snapshot
+FROM quay.io/conforma/cli:snapshot
 
 USER 0
 


### PR DESCRIPTION
This commit updates references to the ec-cli repository as part of the move of that repo from `enterprise-contract/ec-cli` to `conforma/cli`

Ref: EC-1110