### PR TITLE
chore: add CODEOWNERS designating the devs team as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default code owners for this repository.
+# Applies to all paths, including .github/.
+* @conforma/devs


### PR DESCRIPTION
## What

Add a CODEOWNERS file assigning all paths to the Conforma devs team.

## Why

The repo had no CODEOWNERS, so code-owner review resolved to no one. A single `*` owner (the devs team) provides ownership for every path, including `.github/`, and lets code-owner review be required via branch protection.

Co-Authored-By: Claude <noreply@anthropic.com>
Ref: EC-2150